### PR TITLE
14 루틴 수정 기능 추가

### DIFF
--- a/src/api/routine.api.ts
+++ b/src/api/routine.api.ts
@@ -24,6 +24,10 @@ export interface RoutineForm {
   mateNickname: string;
 }
 
+export interface RoutineUpdateForm extends RoutineForm {
+  routineId: number;
+}
+
 export const fetchRoutines = async (
   nickname: string,
   date: string,
@@ -41,6 +45,10 @@ export const fetchRoutineDetail = async (id: number): Promise<Routine> => {
 
 export const createRoutine = async (form: RoutineForm): Promise<void> => {
   return http.post('/routine', form);
+};
+
+export const updateRoutine = async (form: RoutineUpdateForm): Promise<void> => {
+  return http.put('/routine', form);
 };
 
 export const deleteRoutine = async (id: number): Promise<void> => {

--- a/src/api/routine.api.ts
+++ b/src/api/routine.api.ts
@@ -1,7 +1,7 @@
 import http from '.';
 
 export interface Routine {
-  id: number;
+  routineId: number;
   nickname: string;
   routineName: string;
   startDate: string;

--- a/src/components/common/skelton/Skeleton.tsx
+++ b/src/components/common/skelton/Skeleton.tsx
@@ -3,17 +3,17 @@ import { useMemo } from 'react';
 import { useAnimation } from '@/hooks/useAnimation';
 import { toPxels } from '@/utils/css-utils';
 
-type SkeltonVariants = 'pulse';
+type SkeletonVariants = 'pulse';
 
 interface SkeltonProps {
   show: boolean;
-  variant?: SkeltonVariants;
+  variant?: SkeletonVariants;
   width?: string | number;
   height?: string | number;
   className?: string;
 }
 
-const variantStyles: Record<SkeltonVariants, string> = {
+const variantStyles: Record<SkeletonVariants, string> = {
   pulse: 'w-full h-full animate-pulse bg-gray-200',
 };
 

--- a/src/components/modal/RoutineEditModal.tsx
+++ b/src/components/modal/RoutineEditModal.tsx
@@ -1,34 +1,46 @@
 import { RoutineForm as RoutineFormType } from '@/api/routine.api';
-import { useCreateRoutineMutation } from '@/hooks/useRoutine';
+import {
+  useRoutineDetailQuery,
+  useUpdateRoutineMutation,
+} from '@/hooks/useRoutine';
 import { useAuthStore } from '@/store/auth.store';
 import { useModalStore } from '@/store/modal.store';
+import { useRoutineStore } from '@/store/routine.store';
 
 import RoutineForm from '../routine/RoutineForm';
 
-const RoutineAddModal = () => {
+const RoutineEditModal = () => {
   const closeModal = useModalStore((state) => state.close);
+  const routineId = useRoutineStore((state) => state.routineId);
   const user = useAuthStore((state) => state.user);
+  const { data: detail } = useRoutineDetailQuery(routineId);
   const mateNickname = user === 'yunji' ? 'moon' : 'yunji';
 
-  const saveMutation = useCreateRoutineMutation(user);
+  const updateMutation = useUpdateRoutineMutation(user);
 
   const handleSubmit = async (data: RoutineFormType) => {
     try {
-      await saveMutation.mutateAsync(data);
-      alert('루틴이 생성되었습니다.');
+      await updateMutation.mutateAsync({
+        ...data,
+        routineId,
+      });
+      alert('루틴이 수정되었습니다.');
       closeModal();
     } catch {
-      alert('루틴 생성에 실패했습니다.');
+      alert('루틴 수정에 실패했습니다.');
     }
   };
+
+  if (!detail) return null;
 
   return (
     <RoutineForm
       nickname={user}
       mateNickname={mateNickname}
+      form={detail}
       onSubmit={handleSubmit}
     />
   );
 };
 
-export default RoutineAddModal;
+export default RoutineEditModal;

--- a/src/components/providers/ModalProvider.tsx
+++ b/src/components/providers/ModalProvider.tsx
@@ -6,6 +6,7 @@ import Modal from '../common/Modal';
 import RequestDetailModal from '../modal/RequestDetailModal';
 import RoutineAddModal from '../modal/RoutineAddModal';
 import RoutineDetailModal from '../modal/RoutineDetailModal';
+import RoutineEditModal from '../modal/RoutineEditModal';
 import RoutineRequestModal from '../modal/RoutineRequestModal';
 
 interface ModalContainerProps {
@@ -20,6 +21,10 @@ const ModalContainer = ({ name }: ModalContainerProps) => {
     case ModalName.ROUTINE_ADD:
       title = '루틴 추가';
       children = <RoutineAddModal />;
+      break;
+    case ModalName.ROUTINE_EDIT:
+      title = '루틴 수정';
+      children = <RoutineEditModal />;
       break;
     case ModalName.ROUTINE_DETAIL:
       title = '루틴 확인';

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -19,14 +19,14 @@ const FormLabel = ({ children }: FormLabelProps) => {
 };
 
 interface RequestFormProps {
-  id: number;
+  routineId: number;
   routineName: string;
   routineDetail: string;
   nickname: string;
 }
 
 const RequestForm = ({
-  id,
+  routineId,
   routineName,
   routineDetail,
   nickname,
@@ -49,7 +49,7 @@ const RequestForm = ({
     const formData = new FormData();
 
     formData.append('image', image);
-    formData.append('routineId', id.toString());
+    formData.append('routineId', routineId.toString());
     formData.append('nickname', nickname);
 
     try {
@@ -63,7 +63,7 @@ const RequestForm = ({
 
   return (
     <form onSubmit={handleSubmit}>
-      <input className="hidden" name="routineId" defaultValue={id} />
+      <input className="hidden" name="routineId" defaultValue={routineId} />
       <input className="hidden" name="nickname" defaultValue={nickname} />
       <div className="flex flex-col gap-2 mt-5">
         <FormLabel>루틴 이름</FormLabel>

--- a/src/components/routine/RoutineForm.tsx
+++ b/src/components/routine/RoutineForm.tsx
@@ -1,5 +1,4 @@
-import { RoutineForm as RoutineFormType } from '@/api/routine.api';
-import { useCreateRoutineMutation } from '@/hooks/useRoutine';
+import { Routine, RoutineForm as RoutineFormType } from '@/api/routine.api';
 import { useModalStore } from '@/store/modal.store';
 
 import Button from '../common/button/Button';
@@ -12,6 +11,8 @@ import RoutineSubmitButton from './RoutineSubmitButton';
 interface RoutineFormProps {
   nickname: string;
   mateNickname: string;
+  form?: Routine;
+  onSubmit: (data: RoutineFormType) => void;
 }
 
 const routineFormInit = {
@@ -25,27 +26,22 @@ const routineFormInit = {
   mateNickname: '',
 };
 
-const RoutineForm = ({ nickname, mateNickname }: RoutineFormProps) => {
+const RoutineForm = ({
+  nickname,
+  mateNickname,
+  form: formData,
+  onSubmit,
+}: RoutineFormProps) => {
   const closeModal = useModalStore((state) => state.close);
   const form: RoutineFormType = {
     ...routineFormInit,
     nickname,
     mateNickname,
-  };
-  const saveMutation = useCreateRoutineMutation(nickname);
-
-  const handleSubmit = async (data: RoutineFormType) => {
-    try {
-      await saveMutation.mutateAsync(data);
-      alert('루틴이 생성되었습니다.');
-      closeModal();
-    } catch {
-      alert('루틴 생성에 실패했습니다.');
-    }
+    ...formData,
   };
 
   return (
-    <Form data={form} onSubmit={handleSubmit}>
+    <Form data={form} onSubmit={onSubmit}>
       <FormItem
         name="routineName"
         className="flex flex-col gap-2 mt-5"

--- a/src/components/routine/RoutineList.tsx
+++ b/src/components/routine/RoutineList.tsx
@@ -61,12 +61,12 @@ const RoutineList = ({ routines, date }: RoutineListProps) => {
           루틴을 추가해보세요.
         </div>
       )}
-      {routines.map(({ id, routineName, count = 0, routineCount }) => (
-        <ul className="flex w-full text-center" key={id}>
+      {routines.map(({ routineId, routineName, count = 0, routineCount }) => (
+        <ul className="flex w-full text-center" key={routineId}>
           <li className="text-sm truncate py-2 px-1 w-[100px] text-[var(--primary-color)]">
             <span
               className="cursor-pointer hover:underline hover:text-gray-500"
-              onClick={() => handleShowDetailModal(id)}
+              onClick={() => handleShowDetailModal(routineId)}
             >
               {routineName}
             </span>
@@ -109,7 +109,7 @@ const RoutineList = ({ routines, date }: RoutineListProps) => {
                 className="px-2"
                 icon={<IconCheck height={15} stroke={2} />}
                 size="small"
-                onClick={() => handleShowRequestModal(id)}
+                onClick={() => handleShowRequestModal(routineId)}
               />
             ) : (
               <div></div>

--- a/src/components/routine/RoutineView.tsx
+++ b/src/components/routine/RoutineView.tsx
@@ -1,13 +1,14 @@
 import { Routine } from '@/api/routine.api';
 import { useDeleteRoutineMutation } from '@/hooks/useRoutine';
-import { useModalStore } from '@/store/modal.store';
+import { ModalName, useModalStore } from '@/store/modal.store';
+import { useRoutineStore } from '@/store/routine.store';
 import { getDisplayFormatDate } from '@/utils/date-utils';
 
 import Button from '../common/button/Button';
 import Paragraph from '../common/paragraph/Paragraph';
 
 const RoutineView = ({
-  id,
+  routineId,
   nickname,
   routineName,
   routineDetail,
@@ -16,19 +17,27 @@ const RoutineView = ({
   startDate,
   endDate,
 }: Routine) => {
+  const openModal = useModalStore((state) => state.show);
   const closeModal = useModalStore((state) => state.close);
+  const setRoutineId = useRoutineStore((state) => state.setRoutineId);
+
   const deleteRoutine = useDeleteRoutineMutation(nickname);
 
   const handleDelete = async () => {
     if (confirm('정말 삭제하시겠습니까?')) {
       try {
-        await deleteRoutine.mutateAsync(id);
+        await deleteRoutine.mutateAsync(routineId);
         alert('삭제되었습니다.');
         closeModal();
       } catch {
         alert('삭제에 실패했습니다.');
       }
     }
+  };
+
+  const handleEdit = () => {
+    openModal(ModalName.ROUTINE_EDIT);
+    setRoutineId(routineId);
   };
 
   return (
@@ -72,6 +81,12 @@ const RoutineView = ({
           onClick={closeModal}
         >
           확인
+        </Button>
+        <Button
+          className="mr-2 bg-sky-400 hover:bg-sky-500 px-4 disabled:opacity-30 disabled:cursor-not-allowed"
+          onClick={handleEdit}
+        >
+          수정
         </Button>
         <Button
           className="mr-2 px-4 bg-red-400 hover:bg-red-500 disabled:opacity-30 disabled:cursor-not-allowed"

--- a/src/hooks/useRoutine.ts
+++ b/src/hooks/useRoutine.ts
@@ -27,6 +27,21 @@ export const useCreateRoutineMutation = (nickname: string) => {
   });
 };
 
+export const useUpdateRoutineMutation = (nickname: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: routineApi.RoutineUpdateForm) =>
+      routineApi.updateRoutine(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...routineKey.list(nickname)],
+      });
+    },
+  });
+};
+
 export const useRoutineDetailQuery = (routineId: number) => {
   return useQuery({
     queryKey: routineKey.detail(routineId),

--- a/src/store/modal.store.ts
+++ b/src/store/modal.store.ts
@@ -3,6 +3,7 @@ import { devtools } from 'zustand/middleware';
 
 export enum ModalName {
   ROUTINE_ADD = 'routine_add',
+  ROUTINE_EDIT = 'routine_edit',
   ROUTINE_DETAIL = 'routine_detail',
   ROUTINE_REQUEST = 'routine_request',
   REQUEST_DETAIL = 'request_detail',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 루틴 수정 모달이 추가되어 루틴 정보를 수정할 수 있습니다.
  - 루틴 편집 기능이 루틴 상세 화면에 추가되었습니다.

- **버그 수정**
  - Skeleton 컴포넌트의 타입 이름 오타를 수정했습니다.

- **개선 및 변경**
  - 루틴 관련 데이터 및 컴포넌트의 id 속성이 routineId로 변경되었습니다.
  - 루틴 폼이 외부에서 제출 핸들러와 초기값을 받을 수 있도록 개선되었습니다.
  - 요청 폼의 prop 이름이 id에서 routineId로 변경되었습니다.

- **기타**
  - 루틴 수정 관련 API 및 커스텀 훅이 추가되었습니다.
  - 모달 타입에 루틴 수정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->